### PR TITLE
Add options for language and custom word list

### DIFF
--- a/Sources/tinyocr/main.swift
+++ b/Sources/tinyocr/main.swift
@@ -8,25 +8,36 @@ import Foundation
 struct tinyocr: ArgumentParser.ParsableCommand {
     public static let configuration = CommandConfiguration(abstract: "Perform OCR on every image passed a command line argument, output to stdout")
 
+    @Option
+    var lang: [String] = ["en"]
+
+    @Option(help: "Custom word list from file",
+            completion: .file(extensions: ["txt"]))
+    var words: String?
+
     @Argument(completion: .file(extensions: ["jpeg","jpg","png","tiff"])) // support more?
     var files: [String] = []
 
     mutating func run() throws {
+        // build the request handler and perform the request
+        let request = VNRecognizeTextRequest { (request, error) in
+            let observations = request.results as? [VNRecognizedTextObservation] ?? []
+            // take the most likely result for each chunk, then send them all the stdout
+            let obs : [String] = observations.map { $0.topCandidates(1).first?.string ?? ""}
+            print(obs.joined(separator: "\n"))
+        }
+        request.recognitionLevel = VNRequestTextRecognitionLevel.accurate
+        request.usesLanguageCorrection = true
+        request.revision = VNRecognizeTextRequestRevision2
+        request.recognitionLanguages = lang
+        if words != nil {
+            let text = try String(contentsOfFile: words!)
+            request.customWords = text.components(separatedBy: "\n")
+        }
         for url in files.map({ URL(fileURLWithPath: $0) }) {
             guard let imgRef = NSImage(byReferencing: url).cgImage(forProposedRect: nil, context: nil, hints: nil) else {
                 fatalError("Error: could not convert NSImage to CGImage - '\(url)'")
             }
-            // build the request handler and perform the request
-            let request = VNRecognizeTextRequest { (request, error) in
-                let observations = request.results as? [VNRecognizedTextObservation] ?? []
-                // take the most likely result for each chunk, then send them all the stdout
-                let obs : [String] = observations.map { $0.topCandidates(1).first?.string ?? ""}
-                print(obs.joined(separator: "\n"))
-            }
-            request.recognitionLevel = VNRequestTextRecognitionLevel.accurate
-            request.usesLanguageCorrection = true
-            request.revision = VNRecognizeTextRequestRevision2
-            request.recognitionLanguages = ["en"]
             try? VNImageRequestHandler(cgImage: imgRef, options: [:]).perform([request])
         }
     }


### PR DESCRIPTION
I had a go at adding options for the language and a custom word list file.
I moved the construction of the request object outside of the file loop to avoid reading the wordlist multiple times.
I have no experience with Swift whatsoever, so this is probably horrible code, but I've checked that it does at least compile.

Fixes #2 (once properly cleaned up)